### PR TITLE
tile() and slidingWindows() now preserve names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Provides efficient low-level and highly reusable S4
 	neighbors. Defines efficient list-like classes for storing,
 	transforming and aggregating large grouped data, i.e., collections
 	of atomic vectors and DataFrames.
-Version: 2.13.26
+Version: 2.13.27
 Encoding: UTF-8
 Author: H. Pagès, P. Aboyoun and M. Lawrence
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>

--- a/R/tile-methods.R
+++ b/R/tile-methods.R
@@ -40,7 +40,7 @@ setMethod("tile", "IntegerRanges", function(x, n, width, ...) {
                     rep(width, n))
   tile.end.abs <- tile.end + rep(start(x), n) - 1L
   tile.width <- S4Vectors:::diffWithInitialZero(as.integer(tile.end.abs))
-  p <- PartitioningByWidth(n)
+  p <- PartitioningByWidth(n, names = names(x))
   tile.width[start(p)] <- tile.end[start(p)]
   relist(IRanges(width=tile.width, end=tile.end.abs), p)
 })
@@ -69,5 +69,5 @@ setMethod("slidingWindows", "IntegerRanges", function(x, width, step = 1L) {
     windows <- restrict(IRanges(window.starts, width=width),
                         end=rep(width(x), n))
     windows.abs <- shift(windows, rep(start(x), n) - 1L)
-    relist(windows.abs, PartitioningByWidth(n))
+    relist(windows.abs, PartitioningByWidth(n, names = names(x)))
 })

--- a/inst/unitTests/test_tile-methods.R
+++ b/inst/unitTests/test_tile-methods.R
@@ -24,6 +24,9 @@ test_tile <- function() {
   checkException(tile(ir, n=4), silent=TRUE)
   checkException(tile(ir, width=-1), silent=TRUE)
   checkException(tile(ir, n=-1), silent=TRUE)
+  ir <- setNames(IRanges(1:3, width = 10), letters[1:3])
+  checkIdentical(names(ir), names(tile(ir, n = 2)))
+  checkIdentical(names(ir), names(tile(ir, width = 3)))
 }
 
 test_slidingWindows <- function() {
@@ -35,4 +38,6 @@ test_slidingWindows <- function() {
                    IRangesList(IRanges(c(1, 3), c(3, 5)),
                                IRanges(c(2, 4), c(4, 5)),
                                IRanges(3, 5)))
+    ir <- setNames(IRanges(1:3, width = 10), letters[1:3])
+    checkIdentical(names(ir), names(slidingWindows(ir, width = 3)))
 }


### PR DESCRIPTION
This would've been useful to me the other day. Might help others, too