### PR TITLE
fixed removed rownames upon replacing in a SplitDataFrameList

### DIFF
--- a/R/DataFrameList-class.R
+++ b/R/DataFrameList-class.R
@@ -228,7 +228,6 @@ setMethod("normalizeSingleBracketReplacementValue", "SplitDataFrameList",
     function(value, x)
     {
         value <- callNextMethod()  # call default method
-        rownames(value) <- NULL
         if (length(x) != 0L && ncol(x)[[1L]] == ncol(value)[[1L]])
             colnames(value)[[1L]] <- colnames(x)[[1L]]
         value

--- a/inst/unitTests/test_DataFrameList.R
+++ b/inst/unitTests/test_DataFrameList.R
@@ -227,3 +227,12 @@ test_DataFrameList_transform <- function() {
   
   checkIdentical(ANS, DataFrame(df))
 }
+
+test_SplitDataFrameList_rownames <- function() {
+  csdfl <- SplitDataFrameList(DataFrame(one = c(1,2,3,4), row.names = seq_len(4)),
+                              DataFrame(one = c(11,12,13,14), row.names = c("a","b","c","d")))
+  csdfl[[1]] <- DataFrame(one = c(4,3,2,1), row.names = rev(seq_len(4)))
+  csdfl2 <- SplitDataFrameList(DataFrame(one = c(1,2,3,4), row.names = rev(seq_len(4))), 
+                               DataFrame(one = c(11,12,13,14), row.names = c("a","b","c","d")))
+  checkIdentical(rownames(csdfl), rownames(csdfl2))
+}


### PR DESCRIPTION
This removes the hard coded `rownames(x) <- NULL` call from `setMethod("normalizeSingleBracketReplacementValue", "SplitDataFrameList")`. (See #6)

I couldn't find any averse effects. However, since it was hardcoded I am not sure, whether this blocks something else by accident

The call was introduced in 3d94b59268e8983a8bcae9316e465839b987bf7e