### PR TITLE
Propagate mcols NormalIRanges

### DIFF
--- a/R/setops-methods.R
+++ b/R/setops-methods.R
@@ -178,6 +178,27 @@ setMethod("intersect", c("CompressedAtomicList", "CompressedAtomicList"),
 ### setdiff()
 ###
 
+### if input x is NormalIRanges, and y is an IntegerRanges,
+### return a NormalIRanges and optionally propagate mcols(x)
+setMethod(
+    f = "setdiff",
+    signature = c("NormalIRanges", "IntegerRanges"),
+    definition = function(x, y, propagate.mcols = FALSE) {
+        
+        # demote, setdiff, then promote to NormalIRanges
+        ans <- setdiff(x = as(object = x, Class = "IntegerRanges"), y = y)
+        ans <- as(x, "NormalIRanges")
+
+        if (propagate.mcols) {
+            idx <- subjectHits(findOverlaps(query = ans, subject = x))
+            mcols(ans) <- mcols(x)[idx,,drop=FALSE]
+        }
+
+        ans
+    }
+)
+
+
 ### Always return an IRanges *instance* whatever IntegerRanges derivatives
 ### are passed to it (e.g. IPos, NCList or NormalIRanges), so does NOT act
 ### like an endomorphism in general.

--- a/inst/unitTests/test_setops-methods.R
+++ b/inst/unitTests/test_setops-methods.R
@@ -67,6 +67,24 @@ test_IRanges_setdiff <- function() {
   checkIdentical(ans, ans0)
 }
 
+
+test_NormalIRanges_IRanges_setdiff <- function() {
+    
+    x <- as(IRanges(c(1, 4, 9), c(5, 7, 10)), 'NormalIRanges')
+    mcols(x)$test1 <- c('a', 'b')
+    
+    y <- IRanges(c(2, 2, 10), c(2, 3, 12))
+    
+    ans0 <- IRanges(c(1,4,9), c(1,7,9))
+    checkIdentical(setdiff(x, y), ans0)
+    
+    
+    mcols(ans0)$test1 <- c('a', 'a', 'b')
+    checkIdentical(setdiff(x, y, propagate.mcols = TRUE), ans0)
+}
+
+
+
 test_IRanges_punion <- function() {
   x <- IRanges(start=c(1,11,21,31,41,51,61,71), end=c(5,10,25,35,40,55,65,75))
   y <- IRanges(start=c(1, 8,18,35,43,48,63,78), end=c(4,15,22,36,45,50,62,79))

--- a/inst/unitTests/test_setops-methods.R
+++ b/inst/unitTests/test_setops-methods.R
@@ -14,6 +14,48 @@ test_IRanges_intersect <- function() {
   checkIdentical(ans, ans0)  
 }
 
+test_NormalIRanges_IRanges_intersect <- function() {
+    
+    x <- as(object = IRanges(c(1, 4, 9), c(5, 7, 10)),
+            Class = 'NormalIRanges')
+    mcols(x)$test1 <- c('a', 'b')
+    
+    y <- IRanges(c(2, 2, 10), c(2, 3, 12))
+    
+    ans0 <- IRanges(c(2,10),c(3,10))
+    
+    checkIdentical(intersect(x, y), ans0)
+    
+    mcols(ans0) <- DataFrame(test1 = c('a', 'b'))
+    checkIdentical(intersect(x, y, propagate.mcols = TRUE), ans0)
+    
+}
+
+test_NormalIRanges_NormalIRanges_intersect <- function() {
+    
+    x <- as(object = IRanges(c(1, 9), c(7, 14)),
+            Class = 'NormalIRanges')
+    mcols(x)$test1 <- c('a', 'b')
+    
+    y <- as(object = IRanges(c(2, 2, 10), c(2, 3, 12)),
+            Class = 'NormalIRanges')
+    mcols(y)$test2 = c('c', 'd')
+    
+    ans0 <- IRanges(c(2,10),c(3,12))
+    
+    checkIdentical(intersect(x, y), ans0)
+
+    mcols(ans0) <- DataFrame(test1 = c('a', 'b'))
+    checkIdentical(intersect(x, y, propagate.mcols = 'x'), ans0)
+
+    mcols(ans0) <- DataFrame(test2 = c('c', 'd'))
+    checkIdentical(intersect(x, y, propagate.mcols = 'y'), ans0)
+
+    mcols(ans0) <- DataFrame(test1 = c('a', 'b'), test2 = c('c', 'd'))
+    checkIdentical(intersect(x, y, propagate.mcols = 'both'), ans0)
+
+}
+
 test_IRanges_setdiff <- function() {
   x <- IRanges(c(1, 4, 9), c(5, 7, 10))
   y <- IRanges(c(2, 2, 10), c(2, 3, 12))


### PR DESCRIPTION
As discussed in https://github.com/Bioconductor/IRanges/issues/12

For intersect, I implemented two new signatures:
1. NormalIRanges, NormalIRanges -- can propagate mcols of none (default), both, x, or y
2. NormalIRanges, IntegerRanges -- can propagate mcols of none (default) or x

I wrote some tests for these new signatures and they pass

For setdiff, I implemented one new signature:
1. NormalIRanges, IntegerRanges -- can propagate mcols of none (default) or x

I wrote tests for this new signature, which currently fail.  (https://github.com/rcorty/IRanges/blob/aaa83ff9fb7fcc54d2c78029839f1a45375ebcf4/inst/unitTests/test_setops-methods.R#L71-L84)  I haven't been able to figure out why.  When I run the individual commands in the function definition on the inputs, the right result is produced, but inside the package, it doesn't work.  Can someone more experienced have a look?  I wonder if it has to do with getting the call dispatched to the correct signature?