### PR TITLE
Proposal and implementation of fixed-width ranges

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Provides efficient low-level and highly reusable S4
 	neighbors. Defines efficient list-like classes for storing,
 	transforming and aggregating large grouped data, i.e., collections
 	of atomic vectors and DataFrames.
-Version: 2.17.5
+Version: 2.17.5.9000
 Encoding: UTF-8
 Author: H. Pagès, P. Aboyoun and M. Lawrence
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
@@ -30,6 +30,7 @@ Collate: range-squeezers.R
 	Ranges-and-RangesList-classes.R
 	IPosRanges-class.R
 	IPosRanges-comparison.R
+	IFWRanges-class.R
 	IntegerRangesList-class.R
 	IRanges-class.R
 	IRanges-constructor.R
@@ -47,6 +48,7 @@ Collate: range-squeezers.R
 	SimpleGrouping-class.R
 	IRangesList-class.R
 	IPosList-class.R
+	IFWRangesList-class.R
 	ViewsList-class.R
 	RleViewsList-class.R
 	RleViewsList-utils.R

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -181,7 +181,7 @@ exportMethods(
     Ops, Math, Math2, Summary, Complex,
     summary,
     drop,
-    start, "start<-", end, "end<-", width, "width<-", pos,
+    start, "start<-", end, "end<-", width, "width<-", pos, fixed_width,
     min, max, range, which.max, which.min,
     diff,
     mean, var, cov, cor, sd, median, quantile, mad, IQR, smoothEnds, runmed,
@@ -283,6 +283,7 @@ export(
     ## Ranges-and-RangesList-classes.R:
     mid,
     isNormal, whichFirstNotNormal,
+    fixed_width,
 
     ## Views-class.R:
     subject,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -32,10 +32,11 @@ exportClasses(
     FactorList, SimpleFactorList,
 
     ## Ranges-and-RangesList-classes.R:
-    Ranges, IntegerRanges, Pos,
+    Ranges, IntegerRanges, Pos, FWRanges,
     RangesList, SimpleRangesList,
     IntegerRangesList, SimpleIntegerRangesList,
     PosList, SimplePosList,
+    FWRangesList, SimpleFWRangesList,
 
     ## IPosRanges-class.R:
     IPosRanges,
@@ -48,6 +49,9 @@ exportClasses(
 
     ## IPos-class.R:
     IPos,
+
+    ## IFWRanges-class.R:
+    IFWRanges,
 
     ## Grouping-class.R:
     Grouping, ManyToOneGrouping, ManyToManyGrouping,
@@ -73,6 +77,9 @@ exportClasses(
 
     ## IPosList-class.R:
     IPosList, SimpleIPosList,
+
+    ## IFWRangesList-class.R:
+    IFWRangesList, SimpleIFWRangesList,
 
     ## ViewsList-class.R:
     ViewsList, SimpleViewsList,
@@ -230,6 +237,7 @@ export(
     asNormalIRanges,
     rangeComparisonCodeToLetter,
     IPos,
+    IFWRanges,
     NCList, NCLists,
     H2LGrouping, Dups,
     PartitioningByEnd, PartitioningByWidth, PartitioningMap,

--- a/R/CompressedRangesList-class.R
+++ b/R/CompressedRangesList-class.R
@@ -71,6 +71,10 @@ setMethod("pos", "CompressedPosList",
     function(x) relist(pos(unlist(x, use.names=FALSE)), x)
 )
 
+setMethod("fixed_width", "CompressedFWRangesList",
+          function(x) fixed_width(unlist(x, use.names=FALSE))
+)
+
 setMethod(".replaceSEW", "CompressedRangesList",
     function(x, FUN, ..., value)
     {

--- a/R/CompressedRangesList-class.R
+++ b/R/CompressedRangesList-class.R
@@ -13,6 +13,11 @@ setClass("CompressedPosList",
     representation("VIRTUAL")
 )
 
+setClass("CompressedFWRangesList",
+    contains=c("FWRangesList", "CompressedRangesList"),
+    representation("VIRTUAL")
+)
+
 setClass("CompressedIntegerRangesList",
     contains=c("IntegerRangesList", "CompressedRangesList"),
     representation("VIRTUAL")
@@ -38,6 +43,11 @@ setClass("CompressedNormalIRangesList",
 setClass("CompressedIPosList",
     contains=c("IPosList", "CompressedPosList", "CompressedIntegerRangesList"),
     prototype=prototype(unlistData=new("IPos"))
+)
+
+setClass("CompressedIFWRangesList",
+    contains=c("IFWRangesList", "CompressedFWRangesList", "CompressedIntegerRangesList"),
+    prototype=prototype(unlistData=new("IFWRanges"))
 )
 
 
@@ -320,5 +330,28 @@ setAs("IntegerRanges", "IPosList",
 
 setAs("IRanges", "IPosList",
     .from_IntegerRanges_to_CompressedIPosList
+)
+
+### Coercion from IntegerRanges to IFWRangesList.
+
+.from_IntegerRanges_to_CompressedIFWRangesList <- function(from)
+{
+  from <- as(from, "IRanges")
+  ans <- relist(IFWRanges(from), from)
+  metadata(ans) <- metadata(from)
+  mcols(ans) <- mcols(from, use.names=FALSE)
+  ans
+}
+
+setAs("IntegerRanges", "CompressedIFWRangesList",
+      .from_IntegerRanges_to_CompressedIFWRangesList
+)
+
+setAs("IntegerRanges", "IFWRangesList",
+      .from_IntegerRanges_to_CompressedIFWRangesList
+)
+
+setAs("IRanges", "IFWRangesList",
+      .from_IntegerRanges_to_CompressedIFWRangesList
 )
 

--- a/R/IFWRanges-class.R
+++ b/R/IFWRanges-class.R
@@ -55,12 +55,14 @@ setMethod("parallelSlotNames", "IFWRanges",
         return(width)
     fixed_width <- unique(width)
     if (length(fixed_width) > 1)
-        if (funname == "bindROWS") {
+        if (is.null(funname)) {
+            stop("'width' must not have more than 1 unique value")
+        } else if (funname == "bindROWS") {
             stop("all the objects to concatenate must have the same width")
-        } else if (funname =="replaceROWS") {
+        } else if (funname == "replaceROWS") {
             stop("replacement value must have the same width as x")
         } else {
-            stop("'width' must not have more than 1 unique value")
+            stop("")
         }
     if (fixed_width < 0)
         stop("negative widths are not allowed")

--- a/R/IFWRanges-class.R
+++ b/R/IFWRanges-class.R
@@ -1,0 +1,233 @@
+### =========================================================================
+### IFWRanges objects
+### -------------------------------------------------------------------------
+###
+### The IFWRanges class is a simple container for storing a vector of integer
+### fixed-width ranges.
+###
+
+setClass("IFWRanges",
+    contains=c("FWRanges", "IPosRanges"),
+    representation(
+        start="integer",
+        width="integer",
+        NAMES="character_OR_NULL"  # R doesn't like @names !!
+    )
+)
+
+# TODO: Comment copied from IPos-class.R; is this really that expensive for
+#       IFWRanges objects?
+### Expensive! (and not needed)
+#setValidity2("IFWRanges", validate_FWRanges)
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### parallelSlotNames()
+###
+
+### Combine the new parallel slots with those of the parent class. Make sure
+### to put the new parallel slots *first*.
+setMethod("parallelSlotNames", "IFWRanges",
+          function(x) c("start", "NAMES", callNextMethod())
+)
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Getters
+###
+
+setMethod("start", "IFWRanges", function(x, ...) x@start)
+
+setMethod("width", "IFWRanges", function(x) rep.int(x@width, length(x)))
+
+setMethod("names", "IFWRanges", function(x) x@NAMES)
+
+setMethod("ranges", "IntegerRanges",
+    function(x, use.names=TRUE, use.mcols=FALSE)
+    {
+        if (!isTRUEorFALSE(use.names))
+            stop("'use.names' must be TRUE or FALSE")
+        if (!isTRUEorFALSE(use.mcols))
+            stop("'use.mcols' must be TRUE or FALSE")
+        ans_start <- start(x)
+        ans_width <- width(x)
+        ans_names <- if (use.names) names(x) else NULL
+        ans_mcols <- if (use.mcols) mcols(x, use.names=FALSE) else NULL
+        new2("IRanges", start=ans_start,
+             width=ans_width,
+             NAMES=ans_names,
+             elementMetadata=ans_mcols,
+             check=FALSE)
+    }
+)
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Constructor
+###
+
+.normarg_fixed_width <- function(width)
+{
+    width <- .normargSEW0(width, "width")
+    if (identical(width, integer()))
+        return(width)
+    width0 <- unique(width)
+    if (length(width0) > 1)
+        stop("'width' must not have more than 1 unique value")
+    if (width0 < 0)
+        stop("negative widths are not allowed")
+    width0
+}
+
+IFWRanges <- function(start=NULL, end=NULL, width=NULL, names=NULL)
+{
+    if (is(start, "IntegerRanges")) {
+        if (!is.null(end) || !is.null(width))
+            stop("'end' and 'width' must be NULLs ",
+                 "when 'start' is an IntegerRanges object")
+        width <- .normarg_fixed_width(width(start))
+        ans <- new2("IFWRanges", start=start(start), width=width,
+                    NAMES=names, check=FALSE)
+        return(ans)
+    }
+    start <- .normargSEW0(start, "start")
+    end <- .normargSEW0(end, "end")
+    width <- .normarg_fixed_width(width)
+    ## Shortcut if user supplied 'width' and one of 'start' or 'end'.
+    if (length(width) && xor(length(start), length(end))) {
+        if (length(start) == 0L)
+            start <- end - width + 1L
+        return(new2("IFWRanges", start=start, width=width, NAMES=names,
+                    check=FALSE))
+    }
+    ## Otherwise construct an IRanges object and coerce to a IFWRanges
+    ## instance.
+    ans <- solveUserSEW0(start, end, width)
+    names(ans) <- names
+    as(ans, "IFWRanges")
+}
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Coercion
+###
+
+.from_IntegerRanges_to_IFWRanges <- function(from)
+{
+    from_width <- width(from)
+    if (!length(from_width))
+        return(new("IFWRanges"))
+    if (!all(from_width == from_width[[1L]]))
+        stop(wmsg("all the ranges in the ", class(from), " object to ",
+                  "coerce to IFWRanges must have the same width"))
+    ans <- IFWRanges(start=start(from), width=width(from), names=names(from))
+    mcols(ans) <- mcols(from, use.names=FALSE)
+    ans
+}
+setAs("IntegerRanges", "IFWRanges", .from_IntegerRanges_to_IFWRanges)
+
+setAs("ANY", "IFWRanges",
+    function(from) .from_IntegerRanges_to_IFWRanges(as(from, "IntegerRanges"))
+)
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Concatenation
+###
+
+.concatenate_IFWRanges_objects <-
+    function(x, objects=list(), use.names=TRUE, ignore.mcols=FALSE, check=TRUE)
+{
+    objects <- S4Vectors:::prepare_objects_to_bind(x, objects)
+    all_objects <- c(list(x), objects)
+
+    # TODO: Is this necessary? Why doesn't bindROWS,IRanges-method have
+    #       something similar?
+    ans_len <- suppressWarnings(sum(lengths(all_objects)))
+    if (is.na(ans_len))
+        stop("too many integer positions to concatenate")
+
+    ## 1. Take care of the non-parallel slots
+
+    ## Concatenate the "width" slots.
+    ## Note that we use direct slot access to avoid materializing the width
+    ## vector (which could be large).
+    width_list <- lapply(all_objects, slot, "width")
+    ans_width <- .normarg_fixed_width(unlist(width_list, use.names=FALSE))
+
+    ## 2. Take care of the parallel slots
+
+    ## Call method for Vector objects to concatenate all the parallel
+    ## slots (only "start", "NAMES", and "elementMetadata" in the case of
+    ## IFWRanges) and stick them into ans.
+    ## Note that there's no need to do anything for the non-parallel slot
+    ## "width" because we've already checked that all objects have the
+    ## same width, so we can just use the width of the first object.
+    ans <- callNextMethod(x, objects, use.names=use.names,
+                          ignore.mcols=ignore.mcols, check=check)
+
+    # TODO: Replacing the "width" slot is redundant because by this point
+    #       it will have inherited the correct width from x@width or
+    #       errored due to .normarg_fixed_width() detecting incompatible
+    #       widths.
+    BiocGenerics:::replaceSlots(ans, width=ans_width,
+                                check=check)
+}
+
+setMethod("bindROWS", "IFWRanges", .concatenate_IFWRanges_objects)
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Low-level setters for IRanges objects.
+###
+### All these low-level setters preserve the length of the object.
+### The choice was made to implement a "resizing" semantic:
+###   (1) changing the start preserves the end (so it changes the width)
+###   (2) changing the end preserves the start (so it changes the width)
+###   (3) changing the width preserves the start (so it changes the end)
+###
+
+.set_IFWRanges_width <- function(x, value, check=TRUE)
+{
+    if (!isTRUEorFALSE(check))
+        stop("'check' must be TRUE or FALSE")
+    value <- .normarg_fixed_width(value)
+    x@width <- value
+    if (check)
+        validObject(x)
+    x
+}
+
+setReplaceMethod("width", "IFWRanges",
+    function(x, ..., value) .set_IFWRanges_width(x, value)
+)
+
+
+set_IFWRanges_names <- function(x, value)
+{
+    x@NAMES <- S4Vectors:::normalize_names_replacement_value(value, x)
+    ## No need to validate an IFWRanges object after setting its names so
+    ## this should be safe.
+    x
+}
+
+setReplaceMethod("names", "IFWRanges", set_IFWRanges_names)
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Subsetting
+###
+
+setMethod("replaceROWS", "IFWRanges",
+    function(x, i, value)
+    {
+        i <- normalizeSingleBracketSubscript(i, x, as.NSBS=TRUE)
+        ans_start <- replaceROWS(start(x), i, start(value))
+        ans_width <- .normarg_fixed_width(c(x@width, value@width))
+        ans_mcols <- replaceROWS(mcols(x, use.names=FALSE), i,
+                                 mcols(value, use.names=FALSE))
+        BiocGenerics:::replaceSlots(x, start=ans_start,
+                                    width=ans_width,
+                                    mcols=ans_mcols,
+                                    check=FALSE)
+    }
+)
+

--- a/R/IFWRanges-class.R
+++ b/R/IFWRanges-class.R
@@ -47,7 +47,6 @@ setMethod("parallelSlotNames", "IFWRanges",
 ### Constructor
 ###
 
-
 .normarg_fixed_width <- function(width, funname = NULL)
 {
     width <- .normargSEW0(width, "width")

--- a/R/IFWRanges-class.R
+++ b/R/IFWRanges-class.R
@@ -218,8 +218,8 @@ setMethod("replaceROWS", "IFWRanges",
     {
         i <- normalizeSingleBracketSubscript(i, x, as.NSBS=TRUE)
         ans_start <- replaceROWS(start(x), i, start(value))
-        ans_fixed_width <- .normarg_fixed_width(c(x@fixed_width,
-                                                  value@fixed_width),
+        ans_fixed_width <- .normarg_fixed_width(c(fixed_width(x),
+                                                  fixed_width(value)),
                                                 "replaceROWS")
         ans_mcols <- replaceROWS(mcols(x, use.names=FALSE), i,
                                  mcols(value, use.names=FALSE))

--- a/R/IFWRangesList-class.R
+++ b/R/IFWRangesList-class.R
@@ -1,0 +1,15 @@
+### =========================================================================
+### IFWRangesList objects
+### -------------------------------------------------------------------------
+
+
+setClass("IFWRangesList",
+    contains=c("FWRangesList", "IntegerRangesList"),
+    representation("VIRTUAL"),
+    prototype(elementType="IFWRanges")
+)
+
+setClass("SimpleIFWRangesList",
+    contains=c("IFWRangesList", "SimpleFWRangesList", "SimpleIntegerRangesList")
+)
+

--- a/R/IPosRanges-class.R
+++ b/R/IPosRanges-class.R
@@ -6,7 +6,7 @@
 ### intervals with integer end points and on the domain of integers.
 ###
 ### The direct IPosRanges subclasses defined in the IRanges package are:
-### IRanges, IPos, NCList, and GroupingRanges.
+### IRanges, IPos, IFWRanges, NCList, and GroupingRanges.
 
 
 setClass("IPosRanges",

--- a/R/Ranges-and-RangesList-classes.R
+++ b/R/Ranges-and-RangesList-classes.R
@@ -172,16 +172,32 @@ setMethod("as.integer", "Pos", function(x) pos(x))
 ### Methods for FWRanges derivatives
 ###
 
-### Overwrite default method with optimized method for FWRanges objects
-### storing width 1 ranges.
-setMethod("end", "FWRanges",
-    function(x, ...)
-    {
-        if (x@width == 1L)
-            return(start(x))
-        callNextMethod()
-    }
+### No fixed_width() setter for now.
+setGeneric("fixed_width", function(x) standardGeneric("fixed_width"))
+
+### FWRanges subclasses must implement a "fixed_width" method as well as one
+### of a "start" or "end" method.
+### Note that the default start() and end() methods below implement a
+### circular relationship. So FWRanges subclasses must overwrite at least 1 of
+### them!
+setMethod("start", "FWRanges",
+          function(x, ...)
+          {
+              if (isTRUE(length(fixed_width(x)) && fixed_width(x) == 1L))
+                  return(end(x))
+              callNextMethod()
+          }
 )
+setMethod("end", "FWRanges",
+          function(x, ...)
+          {
+              if (isTRUE(length(fixed_width(x)) && fixed_width(x) == 1L))
+                  return(start(x))
+              callNextMethod()
+          }
+)
+setMethod("width", "FWRanges", function(x) rep.int(fixed_width(x), length(x)))
+
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Methods for IntegerRanges derivatives
@@ -260,6 +276,18 @@ setMethod("pos", "PosList",
     function(x) as(lapply(x, pos), "SimpleIntegerList")
 )
 
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Methods for FWRangesList derivatives
+###
+
+setMethod("fixed_width", "FWRangesList",
+          function(x) {
+              if (length(x))
+                  return(fixed_width(x[[1L]]))
+              integer(0L)
+          }
+)
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Validity

--- a/R/intra-range-methods.R
+++ b/R/intra-range-methods.R
@@ -135,6 +135,32 @@ setMethod("shift", "IPos",
     }
 )
 
+### Overwrite above method with optimized method for IFWRanges objects.
+### An IPos object cannot hold names so the 'use.names' arg has no effect.
+### NOTE: We only support shifting by a single value at the moment!
+setMethod("shift", "IFWRanges",
+    function(x, shift=0L, use.names=TRUE)
+    {
+        if (!is.numeric(shift))
+            stop("'shift' must be a numeric vector")
+        if (!is.integer(shift))
+            shift <- as.integer(shift)
+        if (length(shift) != 1L) {
+            if (length(shift) != length(x))
+                stop("'shift' must be a single number or have the ",
+                     "length of 'x' when shifting an IFWRanges object")
+            if (length(shift) != 0L) {
+                if (!isConstant(shift))
+                    stop("'shift' must be constant when shifting ",
+                         "an IFWRanges object")
+                shift <- shift[[1L]]
+            }
+        }
+        new_start <- start(x) + shift
+        BiocGenerics:::replaceSlots(x, start=new_start, check=FALSE)
+    }
+)
+
 setMethod("shift", "RangesList",
     function(x, shift=0L, use.names=TRUE)
     {

--- a/R/intra-range-methods.R
+++ b/R/intra-range-methods.R
@@ -136,7 +136,8 @@ setMethod("shift", "IPos",
 )
 
 ### Overwrite above method with optimized method for IFWRanges objects.
-### An IPos object cannot hold names so the 'use.names' arg has no effect.
+### TODO: An IFWRanges object can hold names but 'use.names' arg currently
+###       has no effect.
 ### NOTE: We only support shifting by a single value at the moment!
 setMethod("shift", "IFWRanges",
     function(x, shift=0L, use.names=TRUE)

--- a/R/setops-methods.R
+++ b/R/setops-methods.R
@@ -25,8 +25,8 @@
 ###
 
 ### Always return an IRanges *instance* whatever IntegerRanges derivatives
-### are passed to it (e.g. IPos, NCList or NormalIRanges), so does NOT act
-### like an endomorphism in general.
+### are passed to it (e.g. IPos, IFWRanges, NCList or NormalIRanges), so does
+### NOT act like an endomorphism in general.
 setMethod("union", c("IntegerRanges", "IntegerRanges"),
     function(x, y)
     {
@@ -65,8 +65,8 @@ setMethod("union", c("Pairs", "missing"), function(x, y, ...) {
 ###
 
 ### Always return an IRanges *instance* whatever IntegerRanges derivatives
-### are passed to it (e.g. IPos, NCList or NormalIRanges), so does NOT act
-### like an endomorphism in general.
+### are passed to it (e.g. IPos, IFWRanges, NCList or NormalIRanges), so does
+### NOT act like an endomorphism in general.
 setMethod("intersect", c("IntegerRanges", "IntegerRanges"),
     function(x, y)
     {
@@ -115,8 +115,8 @@ setMethod("intersect", c("CompressedAtomicList", "CompressedAtomicList"),
 ###
 
 ### Always return an IRanges *instance* whatever IntegerRanges derivatives
-### are passed to it (e.g. IPos, NCList or NormalIRanges), so does NOT act
-### like an endomorphism in general.
+### are passed to it (e.g. IPos, IFWRanges, NCList or NormalIRanges), so does
+### NOT act like an endomorphism in general.
 setMethod("setdiff", c("IntegerRanges", "IntegerRanges"),
     function(x, y)
     {

--- a/man/IFWRanges-class.Rd
+++ b/man/IFWRanges-class.Rd
@@ -27,7 +27,7 @@
   The IFWRanges class is a container for storing a set of \emph{fixed-width}
   ranges. The IFWRanges class extends the \link{IntegerRanges} virtual class.
   Note that even though an \link{IRanges} object can be used for storing
-  fixed-width ranges, using an IFWRanges object will be much more
+  fixed-width ranges, using an IFWRanges object will be more
   memory-efficient (roughly half the size in-memory).
 }
 

--- a/man/IFWRanges-class.Rd
+++ b/man/IFWRanges-class.Rd
@@ -10,7 +10,6 @@
 
 % Accessors
 \alias{start,IFWRanges-method}
-\alias{width,IFWRanges-method}
 \alias{names,IFWRanges-method}
 \alias{width<-,IFWRanges-method}
 \alias{names<-,IFWRanges-method}

--- a/man/IFWRanges-class.Rd
+++ b/man/IFWRanges-class.Rd
@@ -135,7 +135,7 @@ IFWRanges(start=NULL, end=NULL, width=NULL, names=NULL)
 
 \examples{
 ## ---------------------------------------------------------------------
-## A. USING THE IFWRanges() CONSTRUCTOR
+## USING THE IFWRanges() CONSTRUCTOR
 ## ---------------------------------------------------------------------
 
 ## Three ways to construct the same IFWRanges object.
@@ -149,9 +149,9 @@ IFWRanges()  # IFWRanges instance of length zero
 IFWRanges(names=character())
 
 ## ---------------------------------------------------------------------
-## A. MANIPULATING IFWRanges OBJECTS
+## MANIPULATING IFWRanges OBJECTS
 ## ---------------------------------------------------------------------
-## All the methods defined for IntegerRanges objects work on IRanges
+## All the methods defined for IntegerRanges objects work on IFWRanges
 ## objects.
 ## See ?IntegerRanges for some examples.
 

--- a/man/IFWRanges-class.Rd
+++ b/man/IFWRanges-class.Rd
@@ -1,0 +1,181 @@
+\name{IFWRanges-class}
+\docType{class}
+
+% IFWRanges objects:
+\alias{class:IFWRanges}
+\alias{IFWRanges-class}
+\alias{IFWRanges}
+
+\alias{parallelSlotNames,IFWRanges-method}
+
+% Accessors
+\alias{start,IFWRanges-method}
+\alias{width,IFWRanges-method}
+\alias{names,IFWRanges-method}
+\alias{width<-,IFWRanges-method}
+\alias{names<-,IFWRanges-method}
+
+% Coercion:
+\alias{coerce,IntegerRanges,IFWRanges-method}
+\alias{coerce,ANY,IFWRanges-method}
+
+\alias{bindROWS,IFWRanges-method}
+
+\title{Memory-efficient representation of fixed-width ranges on the space of integers.}
+
+\description{
+  The IFWRanges class is a container for storing a set of \emph{fixed-width}
+  ranges. The IFWRanges class extends the \link{IntegerRanges} virtual class.
+  Note that even though an \link{IRanges} object can be used for storing
+  fixed-width ranges, using an IFWRanges object will be much more
+  memory-efficient (roughly half the size in-memory).
+}
+
+\usage{
+## IFWRanges constructor:
+IFWRanges(start=NULL, end=NULL, width=NULL, names=NULL)
+}
+
+\arguments{
+  \item{start, end, width}{
+    \code{NULL} or vector of integers (eventually with NAs).
+  }
+  \item{names}{
+    A character vector or \code{NULL}.
+  }
+}
+
+\section{IFWRanges constructor}{
+  Returns the IFWRanges object containing the fixed-width ranges specified
+  by \code{start}, \code{end} and \code{width}. It is most efficient to
+  supply the \code{IFWRanges()} constructor with an integer vector of start
+  positions (\code{start}) and the fixed-width as an \code{integer(1)}
+  vector (\code{width}) (see examples).
+
+  If necessary \code{start}, \code{end} and \code{width} are recycled to
+  the length of the longest (NULL arguments are filled with NAs). After
+  this recycling, each row in the 3-column matrix obtained by binding
+  those 3 vectors together is "solved" i.e. NAs are treated as
+  unknown in the equation \code{end = start + width - 1}. Finally, the
+  solved matrix is returned as an IFWRanges instance. An error is thrown
+  if this solution results in more than one unique 'width' value (i.e. if
+  the ranges are not fixed-width).
+
+  Note that the \code{names} argument is never recycled (to remain
+  consistent with what \code{`names<-`} does on standard vectors).
+}
+
+\value{
+  An IFWRanges object.
+}
+
+\section{Coercion}{
+  From \link{IntegerRanges} to IFWRanges:
+  An \link{IntegerRanges} derivative \code{x} in which all the ranges have
+  a fixed-width can be coerced to an IFWRanges object with
+  \code{as(x, "IFWRanges")}.
+
+  From IFWRanges to \link{IRanges}:
+  An IFWRanges object \code{x} can be coerced to an \link{IRanges} object
+  with \code{as(x, "IRanges")}. However, be aware that the resulting object
+  will use twice as much memory as \code{x}!
+  See "MEMORY USAGE" in the Examples section below.
+
+  From IFWRanges to ordinary R objects:
+  Like with any other \link{IntegerRanges} derivative, \code{as.character()},
+  \code{as.factor()}, and \code{as.data.frame()} work on an IFWRanges object
+  \code{x}.
+}
+
+\section{Subsetting}{
+  An IFWRanges object can be subsetted exactly like an \link{IRanges} object.
+}
+
+\section{Concatenation}{
+  IFWRanges objects can be concatenated with \code{c()} or \code{append()}
+  \strong{provided that all objects have the same fixed-width}.
+  See \code{?\link[S4Vectors]{c}} in the \pkg{S4Vectors} package for
+  more information about concatenating Vector derivatives.
+}
+
+\section{Splitting and Relisting}{
+  Like with an \link{IRanges} object, \code{split()} and \code{relist()} work
+  on an IFWRanges object.
+}
+
+\note{
+  Like for any \link[S4Vectors]{Vector} derivative, the length of an
+  IFWRanges object cannot exceed \code{.Machine$integer.max} (i.e. 2^31 on
+  most platforms).
+}
+
+\author{
+  Peter Hickey
+}
+
+\seealso{
+  \itemize{
+    \item The \link[GenomicRanges]{GFWRanges} class in the
+          \pkg{GenomicRanges} package for a memory-efficient representation
+          of \emph{genomic fixed-width ranges} (i.e. genomic ranges of
+          fixed-width).
+
+    \item \link{IntegerRanges} and \link{IRanges} objects.
+
+    \item \link{IPosRanges-comparison} for comparing and ordering integer
+          ranges and/or positions.
+
+    \item \link{findOverlaps-methods} for finding overlapping
+          integer ranges and/or positions.
+
+    \item \link{nearest-methods} for finding the nearest integer range
+          and/or position.
+  }
+}
+
+\examples{
+## ---------------------------------------------------------------------
+## A. USING THE IFWRanges() CONSTRUCTOR
+## ---------------------------------------------------------------------
+
+## Three ways to construct the same IFWRanges object.
+IFWRanges(start=c(1L, 3L, 7L, 9L), width=1L) # Most efficient
+IFWRanges(width=1, end=c(2, 4, 8, 10))
+IFWRanges(start=c(1, 3, 7, 9), end=c(2, 4, 8, 10))
+
+IFWRanges(-2, 20)  # only one range
+IFWRanges(start=c(2, 0, NA), end=c(NA, NA, 14), width=12)
+IFWRanges()  # IFWRanges instance of length zero
+IFWRanges(names=character())
+
+## ---------------------------------------------------------------------
+## A. MANIPULATING IFWRanges OBJECTS
+## ---------------------------------------------------------------------
+## All the methods defined for IntegerRanges objects work on IRanges
+## objects.
+## See ?IntegerRanges for some examples.
+
+## Concatenating IRanges objects
+ifwr1 <- IFWRanges(c(1, 10, 20), width=5)
+mcols(ifwr1) <- DataFrame(score=runif(3))
+ifwr2 <- IFWRanges(c(101, 110, 120), width=5)
+ifwr3 <- IRanges(c(1001, 1010, 1020), width=10)
+c(ifwr1, ifwr2) ## Works because same width
+\dontrun{
+c(ifwr1, ifwr3) ## This will raise an error because different widths
+}
+
+## ---------------------------------------------------------------------
+## MEMORY USAGE
+## ---------------------------------------------------------------------
+
+## Coercion to IRanges works...
+ifwr4 <- IFWRanges(sample(10^6, 10^4), width=1)
+ir4 <- as(ifwr4, "IRanges")
+ir4
+## ... but is generally not a good idea:
+object.size(ifwr4)
+object.size(ir4)  # 2-times bigger than the IFWRanges object.
+}
+\keyword{methods}
+\keyword{classes}

--- a/man/IPosRanges-class.Rd
+++ b/man/IPosRanges-class.Rd
@@ -17,6 +17,7 @@
 \alias{width,Pos-method}
 \alias{names,Pos-method}
 \alias{names<-,Pos-method}
+\alias{end,FWRanges-method}
 \alias{elementNROWS,Ranges-method}
 \alias{mid}
 \alias{mid,Ranges-method}
@@ -83,8 +84,8 @@
   which can be subsetted by row and by column).
 
   The IPosRanges class itself is a virtual class. The following classes
-  derive directly from it: \link{IRanges}, \link{IPos}, \link{NCList},
-  and \link{GroupingRanges}.
+  derive directly from it: \link{IRanges}, \link{IPos}, \link{IFWRanges},
+  \link{NCList}, and \link{GroupingRanges}.
 }
 
 \section{Methods}{
@@ -133,8 +134,8 @@
     \item{}{
       \code{tile(x, n, width, ...)}:
       Splits each range in \code{x} into subranges as specified by \code{n}
-      (number of ranges) or \code{width}. Only one of \code{n} or \code{width} 
-      can be specified. The return value is a \code{IRangesList} the same 
+      (number of ranges) or \code{width}. Only one of \code{n} or \code{width}
+      can be specified. The return value is a \code{IRangesList} the same
       length as \code{x}. IPosRanges with a width less than the \code{width}
       argument are returned unchanged.
     }
@@ -219,8 +220,8 @@
       \code{show(x)}:
       By default the \code{show} method displays 5 head and 5 tail
       lines. The number of lines can be altered by setting the global
-      options \code{showHeadLines} and \code{showTailLines}. If the 
-      object length is less than the sum of the options, the full object 
+      options \code{showHeadLines} and \code{showTailLines}. If the
+      object length is less than the sum of the options, the full object
       is displayed. These options affect display of \link{IRanges},
       \link{IPos}, \link[S4Vectors]{Hits}, \link[GenomicRanges]{GRanges},
       \link[GenomicRanges]{GPos}, \link[GenomicAlignments]{GAlignments},
@@ -288,6 +289,10 @@
     \item The \link{IPos} class, a memory-efficient IPosRanges derivative
           for representing \emph{integer positions} (i.e. integer
           ranges of width 1).
+
+    \item The \link{IFWRanges} class, a memory-efficient IPosRanges
+          derivative for representing fixed-width ranges on the space of
+          integers.
 
     \item \link{IPosRanges-comparison} for comparing and ordering ranges.
 

--- a/man/IPosRanges-class.Rd
+++ b/man/IPosRanges-class.Rd
@@ -17,7 +17,9 @@
 \alias{width,Pos-method}
 \alias{names,Pos-method}
 \alias{names<-,Pos-method}
+\alias{start,FWRanges-method}
 \alias{end,FWRanges-method}
+\alias{width,FWRanges-method}
 \alias{elementNROWS,Ranges-method}
 \alias{mid}
 \alias{mid,Ranges-method}
@@ -337,7 +339,7 @@ width(x) <- width(x) * 2 + 1
 x
 end(x) <- start(x)            # equivalent to width(x) <- 0
 x
-width(x) <- c(2, 0, 4) 
+width(x) <- c(2, 0, 4)
 x
 start(x)[3] <- end(x)[3] - 2  # resize the 3rd range
 x

--- a/man/IPosRanges-comparison.Rd
+++ b/man/IPosRanges-comparison.Rd
@@ -17,7 +17,8 @@
 
 \description{
   Methods for comparing and/or ordering the ranges in \link{IPosRanges}
-  derivatives (e.g. \link{IRanges}, \link{IPos}, or \link{NCList} objects).
+  derivatives (e.g. \link{IRanges}, \link{IPos}, \link{IFWRanges} or
+  \link{NCList} objects).
 }
 
 \usage{
@@ -47,8 +48,8 @@ rangeComparisonCodeToLetter(code)
 
 \arguments{
   \item{x, table, y}{
-    \link{IPosRanges} derivatives e.g. \link{IRanges}, \link{IPos}, or
-    \link{NCList} objects.
+    \link{IPosRanges} derivatives e.g. \link{IRanges}, \link{IPos},
+    \link{IFWRanges} or \link{NCList} objects.
   }
   \item{nomatch}{
     The value to be returned in the case when no match is found.

--- a/man/intra-range-methods.Rd
+++ b/man/intra-range-methods.Rd
@@ -9,6 +9,7 @@
 \alias{shift}
 \alias{shift,Ranges-method}
 \alias{shift,IPos-method}
+\alias{shift,IFWRanges-method}
 \alias{shift,RangesList-method}
 
 \alias{narrow}
@@ -44,8 +45,8 @@
 \alias{Ops,CompressedRangesList,numeric-method}
 
 
-\title{Intra range transformations of an IRanges, IPos, Views, RangesList,
-       or MaskCollection object}
+\title{Intra range transformations of an IRanges, IPos, IFWRanges, Views,
+       RangesList, or MaskCollection object}
 
 \description{
   Range-based transformations are grouped in 2 categories:
@@ -91,8 +92,8 @@ threebands(x, start=NA, end=NA, width=NA)
 
 \arguments{
   \item{x}{
-    An \link{IRanges}, \link{IPos}, \link{Views}, \link{RangesList}, or
-    \link{MaskCollection} object.
+    An \link{IRanges}, \link{IPos}, \link{IFWRanges}, \link{Views},
+    \link{RangesList}, or \link{MaskCollection} object.
   }
   \item{shift}{
     An integer vector containing the shift information. Recycled as
@@ -105,7 +106,8 @@ threebands(x, start=NA, end=NA, width=NA)
     \code{TRUE} or \code{FALSE}. Should names be preserved?
   }
   \item{start, end}{
-    If \code{x} is an \link{IRanges}, \link{IPos} or \link{Views} object:
+    If \code{x} is an \link{IRanges}, \link{IPos}, \link{IFWRanges} or
+    \link{Views} object:
     A vector of integers for all functions except for \code{flank}.
     For \code{restrict}, the supplied \code{start} and \code{end}
     arguments must be vectors of integers, eventually with NAs, that
@@ -123,7 +125,8 @@ threebands(x, start=NA, end=NA, width=NA)
     if \code{x} is a \link{RangesList} object.
   }
   \item{width}{
-    If \code{x} is an \link{IRanges}, \link{IPos} or \link{Views} object:
+    If \code{x} is an \link{IRanges}, \link{IPos}, \link{IFWRanges}
+    or \link{Views} object:
     For \code{narrow} and \code{threebands}, a vector of integers,
     eventually with NAs. See the SEW (Start/End/Width) interface for
     the details (\code{?solveUserSEW}).
@@ -136,7 +139,8 @@ threebands(x, start=NA, end=NA, width=NA)
     if \code{x} is a \link{RangesList} object.
   }
   \item{fix}{
-    If \code{x} is an \link{IRanges}, \link{IPos} or \link{Views} object:
+    If \code{x} is an \link{IRanges}, \link{IPos}, \link{IFWRanges}
+    or \link{Views} object:
     A character vector or character-Rle of length 1 or \code{length(x)}
     containing the values \code{"start"}, \code{"end"}, and
     \code{"center"} denoting what to use as an anchor for each
@@ -294,8 +298,8 @@ threebands(x, start=NA, end=NA, width=NA)
   \itemize{
     \item \link{inter-range-methods} for inter range transformations.
 
-    \item The \link{IRanges}, \link{IPos}, \link{Views}, \link{RangesList},
-          and \link{MaskCollection} classes.
+    \item The \link{IRanges}, \link{IPos}, \link{IFWRanges}, \link{Views},
+    \link{RangesList}, and \link{MaskCollection} classes.
 
     \item The \link[GenomicRanges]{intra-range-methods} man page in the
           \pkg{GenomicRanges} package for \emph{intra range transformations}


### PR DESCRIPTION
Hi @hpages and @lawremi,

I'd like to propose the concept of fixed-width / constant-width ranges and an implementation for inclusion in **IRanges** and **GenomicRanges**.

My motivation comes from analysing bisulfite-sequencing data where we may have hundreds of millions of non-adjacent loci all with width of 1.
The current options of storing these as *IRanges* (within a *GRanges*) or *IPos* (within a *GPos*) aren't optimal:
- There is a lot of redundancy when these loci are stored as an *IRanges* object (within a *GRanges* object) because all loci have `start == end`.
- The *IPos* / *GPos* classes aren't efficient for these loci because they are (almost) never adjacent.

My proposal is store only the `start` of these loci (n values) along with their common `fixed_width` (1 value).
For 100,000,000 loci, this halves the object size from ~800 Mb to ~400 Mb.

For a while now, I've had a hacky and incomplete implementation of this idea in the **bsseq** package, and I've long been wanting to tidy it up and finalise it.
Here, I've implemented this idea in the *IFWRanges* class, which serves as a drop-in replacement for *IRanges* in much the same way as *IPos*.

First and foremost, would you be interested in including this in **IRanges**  and **GenomicRanges**? 
These package seem to me the natural homes for these classes and methods, but I guess the alternative is for them to live in their own package.

Secondly, I've got some questions about the implementation where I would appreciate your advice.

1. Have I got the class hierarchy correct? I (manually) updated the ASCII diagram of the class hierarchy to illustrate it: https://github.com/PeteHaitch/IRanges/blob/11d2b45dd7b4d70a5257cef39d18b72a5e8fc0fb/R/Ranges-and-RangesList-classes.R#L23-L46
2. I think the `fixed_width()` generic (and methods) need be exported because *GFWRanges*, which I have written as a patch to **GenomicRanges** (I'll await feedback on this PR before submitting this second PR), will require an implementation. If so:
    a. Should the `fixed_width()` generic be here or in **BiocGenerics** (like `pos()`)?
    b. Is there a way to a have a "developer-facing but not user-facing" cross-package generic? I don't see much need for `fixed_width()` to be user-facing.
3. Should I define an `update_ranges,IFWRanges-method`? It would be extremely limited by design because arbitary intra-range operations on an *IFWRanges* object are not supported, but it would give me a cheap implementation of `resize()` as well as a 'better' implementation of `shift,IFWRanges-method` and (ultimately) `shift,GFWRanges-method`.
4. Following the *IPos* hierarchy, I've not implemented `start()<-` or `end()<-` for the *IFWRanges* hierarchy (since arbitrary changes of either are not supported on fixed-width ranges), but I have implemented a limited `width<-()` since this is easily done. Is this asymmetry okay?
5. `show,IFWRanges-method` defers to `show,IPosRanges-method` which coerces the input to an *IRanges* object. This coercion will double the memory footprint of the object, which it'd be nice to avoid. There's a note in `show_IPosRanges()` saying:
https://github.com/Bioconductor/IRanges/blob/b93d3d18e2a4f821c30094ab02b94fe2181d17f0/R/IPosRanges-class.R#L138-L140
  a. Which *IPosRanges* objects are not subsettable?
  b. Subsetting *IFWRanges* is cheap, so could this coercion perhaps be skipped if `show_IPosRanges()` is given an *IFWRanges* object?
6. The depth of documentation and unit tests is roughly on part with that for the *IPos* hierarchy :)
7. I'm not sure the name "fixed-width" is accurate. For example, it's possible to change the width (e.g., `width(x) <- 2L`) so it's not fixed in that sense. Perhaps constant width is better. I particularly started to think this upon noting the comment below.

While implementing the *IFWRanges* hierarchy, I noticed the `is_constant_width` member of the `struct iranges_holder`.
https://github.com/Bioconductor/IRanges/blob/b93d3d18e2a4f821c30094ab02b94fe2181d17f0/inst/include/IRanges_defines.h#L46-L55
However, it doesn't seem to be used much (at all?) in the code base, so:
    8a. What's this about?
    8b. Could the proposed *IFWRanges* class make use of this?

There's a few other things on my TODO list should this be considered worthwhile:

- [ ] Deal with remaining inline TODOs
- [ ] Update `DESCRIPTION`
    - [ ] Bump version number
    - [ ] Add self to authors
- [ ] Update `NEWS`
- [ ] Document `fixed_width()` (once I know where it's living).
- [ ] Tidy up `.normarg_fixed_width()`. There should be a specific error message depending on the function it is called from (right now, this is half-baked).
- [ ] Add unit tests

I look forward to hearing your thoughts.
Thanks,
Pete
