### PR TITLE
Allow digit grouping in coercion from character

### DIFF
--- a/R/IRanges-class.R
+++ b/R/IRanges-class.R
@@ -205,10 +205,10 @@ setAs("numeric", "NormalIRanges",
         "digit group separators in form of a space or a comma. ",
         "For example: \"2501-2900\", \"2,501..2,900\", or \"740\"."
     )
-    ## We want to split on the first occurence of  "-" that is preceeded by
-    ## a digit (ignoring and removing the spaces in between if any).
     from <- gsub("[,[:space:]]", "", from)
-    from <- sub("([[:digit:]])[[:space:]]*-", "\\1..", from)
+    ## We want to split on the first occurence of "-" that is preceeded by
+    ## a digit.
+    from <- sub("([[:digit:]])-", "\\1..", from)
     split2 <- CharacterList(strsplit(from, "..", fixed=TRUE))
     split2_eltNROWS <- elementNROWS(split2)
     if (!all(split2_eltNROWS <= 2L))

--- a/R/IRanges-class.R
+++ b/R/IRanges-class.R
@@ -201,11 +201,13 @@ setAs("numeric", "NormalIRanges",
     error_msg <- wmsg(
         "The character vector to convert to an IRanges object must ",
         "contain strings of the form \"start-end\" or \"start..end\", ",
-        "with end >= start - 1, or just \"pos\". For example: \"2501-2900\", ",
-        "\"2501..2900\", or \"740\"."
+        "with end >= start - 1, or just \"pos\". pos and end can have ",
+        "digit group separators in form of a space or a comma. ",
+        "For example: \"2501-2900\", \"2,501..2,900\", or \"740\"."
     )
     ## We want to split on the first occurence of  "-" that is preceeded by
     ## a digit (ignoring and removing the spaces in between if any).
+    from <- gsub("[,[:space:]]", "", from)
     from <- sub("([[:digit:]])[[:space:]]*-", "\\1..", from)
     split2 <- CharacterList(strsplit(from, "..", fixed=TRUE))
     split2_eltNROWS <- elementNROWS(split2)


### PR DESCRIPTION
Large numbers are often divided into groups using a delimeter to ease of reading. English often uses comma to create groups of three for thousands, millions etc. IUPAC and International Bureau of Weights and Measures recommend using spaces.
[Wikipedia on digit grouping](https://en.wikipedia.org/wiki/Decimal_separator#Digit_grouping)

Some genomic software uses digit grouping. Notably, IGV and UCSC genome browser use comma for digit grouping.

This pull request allows for a use of commas and spaces in coercion to IRanges from character by stripping all commas and spaces from the input strings. It should work with any currently legal format plus allow for spaces and commas. 

```r
> GRanges("chrX:12,345,678-12,345,999")
GRanges object with 1 range and 0 metadata columns:
      seqnames            ranges strand
         <Rle>         <IRanges>  <Rle>
  [1]     chrX 12345678-12345999      *
  -------
  seqinfo: 1 sequence from an unspecified genome; no seqlengths

> GRanges("chrX:12 345 678..12 345 999")
GRanges object with 1 range and 0 metadata columns:
      seqnames            ranges strand
         <Rle>         <IRanges>  <Rle>
  [1]     chrX 12345678-12345999      *
  -------
  seqinfo: 1 sequence from an unspecified genome; no seqlengths

```

PS. This is code extends GenomicRanges coercion from character as well. If this pull request is approved, error message in `.from_character_to_GRanges` in GenomicRanges needs to be updated as well.


