### PR TITLE
Use commonColnames to get/set the column names of a DataFrameList.

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -297,6 +297,7 @@ export(
     extractList,
 
     ## DataFrameList-class.R:
+    commonColnames, "commonColnames<-",
     columnMetadata, "columnMetadata<-",
 
     ## IntegerRangesList-class.R:
@@ -364,6 +365,7 @@ exportMethods(
     high2low, low2high, grouprank, togrouprank, mapOrder,
     findRange, splitRanges,
     extractList,
+    commonColnames, "commonColnames<-",
     columnMetadata, "columnMetadata<-",
     space,
     nir_list,

--- a/R/CompressedDataFrameList-class.R
+++ b/R/CompressedDataFrameList-class.R
@@ -82,12 +82,6 @@ setReplaceMethod("colnames", "CompressedSplitDataFrameList",
 setMethod("commonColnames", "CompressedSplitDataFrameList",
           function(x) colnames(unlist(x, use.names=FALSE)))
 
-setReplaceMethod("commonColnames", "CompressedSplitDataFrameList",
-                 function(x, value) {
-                   colnames(x@unlistData) <- value
-                   x
-                 })
-
 setMethod("columnMetadata", "CompressedSplitDataFrameList", function(x) {
   mcols(x@unlistData, use.names=FALSE)
 })

--- a/R/CompressedDataFrameList-class.R
+++ b/R/CompressedDataFrameList-class.R
@@ -82,6 +82,12 @@ setReplaceMethod("colnames", "CompressedSplitDataFrameList",
 setMethod("commonColnames", "CompressedSplitDataFrameList",
           function(x) colnames(unlist(x, use.names=FALSE)))
 
+setReplaceMethod("commonColnames", "CompressedSplitDataFrameList",
+                 function(x, value) {
+                   colnames(x@unlistData) <- value
+                   x
+                 })
+
 setMethod("columnMetadata", "CompressedSplitDataFrameList", function(x) {
   mcols(x@unlistData, use.names=FALSE)
 })

--- a/R/DataFrameList-class.R
+++ b/R/DataFrameList-class.R
@@ -164,8 +164,27 @@ setMethod("ROWNAMES", "DataFrameList", function(x) names(x))
 
 setGeneric("commonColnames", function(x) standardGeneric("commonColnames"))
 
-setMethod("commonColnames", "SplitDataFrameList",
-          function(x) colnames(head(x, 1L))[[1L]])
+setMethod("commonColnames", "DataFrameList",
+          function(x) {
+            if (length(x)) 
+              Reduce(intersect, colnames(x))
+            else NULL
+          })
+
+setGeneric("commonColnames<-", function(x, value) standardGeneric("commonColnames<-"))
+
+setReplaceMethod("commonColnames", "SimpleDataFrameList", 
+                 function(x, value) {
+                   old <- commonColnames(x)
+                   stopifnot(length(old)==length(value))
+                   x@listData <- lapply(x@listData, function(xi) {
+                     m <- match(colnames(xi), old)
+                     present <- !is.na(m)
+                     colnames(xi)[present] <- value[m[present]]
+                     xi
+                   })
+                   x
+                 })
 
 setGeneric("columnMetadata", function(x, ...) standardGeneric("columnMetadata"))
 

--- a/R/DataFrameList-class.R
+++ b/R/DataFrameList-class.R
@@ -173,7 +173,7 @@ setMethod("commonColnames", "SimpleSplitDataFrameList",
 
 setGeneric("commonColnames<-", function(x, value) standardGeneric("commonColnames<-"))
 
-setReplaceMethod("commonColnames", "SimpleSplitDataFrameList", 
+setReplaceMethod("commonColnames", "SplitDataFrameList", 
                  function(x, value) {
                    colnames(x) <- value
                    x

--- a/R/DataFrameList-class.R
+++ b/R/DataFrameList-class.R
@@ -164,23 +164,19 @@ setMethod("ROWNAMES", "DataFrameList", function(x) names(x))
 
 setGeneric("commonColnames", function(x) standardGeneric("commonColnames"))
 
-setMethod("commonColnames", "DataFrameList",
+setMethod("commonColnames", "SimpleSplitDataFrameList",
           function(x) {
             if (length(x)) 
-              Reduce(intersect, colnames(x))
+              colnames(x[[1]])
             else NULL
           })
 
 setGeneric("commonColnames<-", function(x, value) standardGeneric("commonColnames<-"))
 
-setReplaceMethod("commonColnames", "SimpleDataFrameList", 
+setReplaceMethod("commonColnames", "SimpleSplitDataFrameList", 
                  function(x, value) {
-                   old <- commonColnames(x)
-                   stopifnot(length(old)==length(value))
                    x@listData <- lapply(x@listData, function(xi) {
-                     m <- match(colnames(xi), old)
-                     present <- !is.na(m)
-                     colnames(xi)[present] <- value[m[present]]
+                     colnames(xi) <- value
                      xi
                    })
                    x

--- a/R/DataFrameList-class.R
+++ b/R/DataFrameList-class.R
@@ -175,10 +175,7 @@ setGeneric("commonColnames<-", function(x, value) standardGeneric("commonColname
 
 setReplaceMethod("commonColnames", "SimpleSplitDataFrameList", 
                  function(x, value) {
-                   x@listData <- lapply(x@listData, function(xi) {
-                     colnames(xi) <- value
-                     xi
-                   })
+                   colnames(x) <- value
                    x
                  })
 

--- a/inst/unitTests/test_DataFrameList.R
+++ b/inst/unitTests/test_DataFrameList.R
@@ -138,6 +138,8 @@ test_SplitDataFrameList_columnUtils <- function() {
     checkIdentical(colnames(out[[1]]), c("a", "b"))
     checkIdentical(colnames(out[[length(out)]]), c("a", "b"))
 
+    checkIdentical(commonColnames(out[0]), c("a", "b"))
+
     # Same behavior for SimpleSDFLs.
     alt <- as(original, "SimpleSplitDataFrameList")
     checkIdentical(commonColnames(alt), c("X", "Y"))
@@ -146,6 +148,8 @@ test_SplitDataFrameList_columnUtils <- function() {
     checkIdentical(commonColnames(alt), c("a", "b"))
     checkIdentical(colnames(alt[[1]]), c("a", "b"))
     checkIdentical(colnames(alt[[length(alt)]]), c("a", "b"))
+
+    checkIdentical(commonColnames(alt[0]), NULL)
 }
 
 test_DataFrameList_replace <- function() {

--- a/inst/unitTests/test_DataFrameList.R
+++ b/inst/unitTests/test_DataFrameList.R
@@ -125,6 +125,29 @@ test_SplitDataFrameList_as.data.frame <- function() {
     }
 }
 
+test_SplitDataFrameList_columnUtils <- function() {
+    set.seed(100001)
+    original <- splitAsList(DataFrame(X=runif(100), Y=rpois(100, 5)), 
+        sample(letters, 100, replace=TRUE))
+
+    out <- original
+    checkIdentical(commonColnames(out), c("X", "Y"))
+
+    commonColnames(out) <- c("a", "b")
+    checkIdentical(commonColnames(out), c("a", "b"))
+    checkIdentical(colnames(out[[1]]), c("a", "b"))
+    checkIdentical(colnames(out[[length(out)]]), c("a", "b"))
+
+    # Same behavior for SimpleSDFLs.
+    alt <- as(original, "SimpleSplitDataFrameList")
+    checkIdentical(commonColnames(alt), c("X", "Y"))
+
+    commonColnames(alt) <- c("a", "b")
+    checkIdentical(commonColnames(alt), c("a", "b"))
+    checkIdentical(colnames(alt[[1]]), c("a", "b"))
+    checkIdentical(colnames(alt[[length(alt)]]), c("a", "b"))
+}
+
 test_DataFrameList_replace <- function() {
     checkDFL2dfl <- function(DFL, dfl) {
         checkIdentical(lapply(as.list(DFL), as.data.frame), dfl)

--- a/man/DataFrameList-class.Rd
+++ b/man/DataFrameList-class.Rd
@@ -73,6 +73,12 @@
 \alias{columnMetadata<-,SimpleSplitDataFrameList-method}
 \alias{columnMetadata,CompressedSplitDataFrameList-method}
 \alias{columnMetadata<-,CompressedSplitDataFrameList-method}
+\alias{commonColnames}
+\alias{commonColnames<-}
+\alias{commonColnames,SimpleSplitDataFrameList-method}
+\alias{commonColnames<-,SimpleSplitDataFrameList-method}
+\alias{commonColnames,CompressedSplitDataFrameList-method}
+\alias{commonColnames<-,CompressedSplitDataFrameList-method}
 
 % subsetting
 \alias{[,SimpleSplitDataFrameList-method}
@@ -135,6 +141,14 @@
       the first holding the rownames (possibly \code{NULL}) and the second
       the column names.
     }
+  }
+
+  In the following code snippets, \code{x} is a \code{SplitDataFrameList}.
+  \describe{
+    \item{}{\code{commonColnames(x)}: Get the character vector of 
+      column names present in the individual DataFrames in \code{x}.} 
+    \item{}{\code{commonColnames(x) <- value}: Set the column names of 
+      the DataFrames in \code{x}.}
     \item{}{\code{columnMetadata(x)}: Get the \code{DataFrame} of
       metadata along the columns, i.e., where each column in \code{x} is
       represented by a row in the metadata. The metadata is common
@@ -241,6 +255,28 @@
       \code{List} man page for details (?\code{List}). 
     }
   }
+}
+
+\examples{
+# Making a DataFrameList, which has different columns.
+out <- DataFrameList(DataFrame(X=1, Y=2), DataFrame(A=1:2, B=3:4))
+out[[1]]
+
+# A more interesting SplitDataFrameList, which is guaranteed
+# to have the same columns.
+out <- DataFrameList(DataFrame(X=1, Y=2), DataFrame(X=1:2, Y=3:4))
+out[[1]]
+out[,"X"]
+out[,"Y"]
+
+commonColnames(out)
+commonColnames(out) <- c("x", "y")
+out[[1]]
+
+# We can also create these split objects using various split() functions:
+out <- splitAsList(DataFrame(X=runif(100), Y=rpois(100, 5)), 
+    sample(letters, 100, replace=TRUE))
+out[[1]]
 }
 
 \author{ Michael Lawrence }

--- a/man/DataFrameList-class.Rd
+++ b/man/DataFrameList-class.Rd
@@ -264,7 +264,7 @@ out[[1]]
 
 # A more interesting SplitDataFrameList, which is guaranteed
 # to have the same columns.
-out <- DataFrameList(DataFrame(X=1, Y=2), DataFrame(X=1:2, Y=3:4))
+out <- SplitDataFrameList(DataFrame(X=1, Y=2), DataFrame(X=1:2, Y=3:4))
 out[[1]]
 out[,"X"]
 out[,"Y"]
@@ -276,7 +276,7 @@ out[[1]]
 # We can also create these split objects using various split() functions:
 out <- splitAsList(DataFrame(X=runif(100), Y=rpois(100, 5)), 
     sample(letters, 100, replace=TRUE))
-out[[1]]
+out[['a']]
 }
 
 \author{ Michael Lawrence }


### PR DESCRIPTION
Needs some tests and docs, but otherwise closes #29.

Usage:

```r
library(IRanges)
test <- split(DataFrame(X=1:10, Y=2:11), letters[1:10])
commonColnames(test)
## [1] "X" "Y"
commonColnames(test) <- c("aaron", "lun")
test[[1]]
## DataFrame with 1 row and 2 columns
##       aaron       lun
##   <integer> <integer>
## 1         1         2

test2 <- List(DataFrame(x=1, y=2), DataFrame(y=2, z=3))
commonColnames(test2)
## [1] "y"
commonColnames(test2) <- "aaron"
test2[[1]]
## DataFrame with 1 row and 2 columns
##           x     aaron
##   <numeric> <numeric>
## 1         1         2
```