### PR TITLE
Fix unmatched braces

### DIFF
--- a/src/NCList.c
+++ b/src/NCList.c
@@ -1223,8 +1223,8 @@ static void pp_find_overlaps(
 					xh_buf2, yh_buf, hits_buf, direct_out);
 		}
 		omp_set_num_threads(old_max_threads);
-#endif
 	}
+#endif
 	return;
 }
 


### PR DESCRIPTION
This PR fixes a build error on [macOS](https://bioconductor.org/checkResults/3.22/bioc-LATEST/IRanges/lconway-buildsrc.html) caused by unmatched braces in the OpenMP conditional compilation block within the pp_find_overlaps function in src/NCList.c.

ping: #60 

The closing brace for the OpenMP else block is now only included when _OPENMP is defined, preventing syntax errors on platforms where OpenMP is not available.

