### PR TITLE
Use '::' for exported name

### DIFF
--- a/R/setops-methods.R
+++ b/R/setops-methods.R
@@ -100,11 +100,11 @@ setMethod("intersect", c("CompressedAtomicList", "CompressedAtomicList"),
           function(x, y) {
               fx <- if (!is(x, "IntegerList")) as(x, "FactorList") else x
               fy <- if (!is(y, "IntegerList")) as(y, "FactorList") else y
-              m <- S4Vectors::matchIntegerPairs(togroup(PartitioningByEnd(x)),
-                                                unlist(fx, use.names=FALSE),
-                                                togroup(PartitioningByEnd(y)),
-                                                unlist(fy, use.names=FALSE),
-                                                nomatch=0L)
+              m <- matchIntegerPairs(togroup(PartitioningByEnd(x)),
+                                     unlist(fx, use.names=FALSE),
+                                     togroup(PartitioningByEnd(y)),
+                                     unlist(fy, use.names=FALSE),
+                                     nomatch=0L)
               m[duplicated(m)] <- 0L
               x[relist(m > 0L, x)]
           })

--- a/R/setops-methods.R
+++ b/R/setops-methods.R
@@ -100,11 +100,11 @@ setMethod("intersect", c("CompressedAtomicList", "CompressedAtomicList"),
           function(x, y) {
               fx <- if (!is(x, "IntegerList")) as(x, "FactorList") else x
               fy <- if (!is(y, "IntegerList")) as(y, "FactorList") else y
-              m <- S4Vectors:::matchIntegerPairs(togroup(PartitioningByEnd(x)),
-                                                 unlist(fx, use.names=FALSE),
-                                                 togroup(PartitioningByEnd(y)),
-                                                 unlist(fy, use.names=FALSE),
-                                                 nomatch=0L)
+              m <- S4Vectors::matchIntegerPairs(togroup(PartitioningByEnd(x)),
+                                                unlist(fx, use.names=FALSE),
+                                                togroup(PartitioningByEnd(y)),
+                                                unlist(fy, use.names=FALSE),
+                                                nomatch=0L)
               m[duplicated(m)] <- 0L
               x[relist(m > 0L, x)]
           })


### PR DESCRIPTION
This is exported:

https://github.com/Bioconductor/S4Vectors/blob/3bddd9ee8fb21083fdf5cbc736817d72c21d516e/NAMESPACE#L337

As reported by `tools:::.check_packages_used`