### PR TITLE
Fix variable name: xlen->x_len

### DIFF
--- a/src/NCList.c
+++ b/src/NCList.c
@@ -486,7 +486,7 @@ static void build_NCList(NCList *top_nclist,
 	if (x_subset_p == NULL) {
 		for (rgid = 0; rgid < x_len; rgid++)
 			base[rgid] = rgid;
-	} else if (xlen != 0) {
+	} else if (x_len != 0) {
 		memcpy(base, x_subset_p, sizeof(int) * x_len);
 	}
 	retcode = sort_int_pairs(base, x_len,


### PR DESCRIPTION
Follow-up to #66

I'm not sure what to make of the other issues, hopefully a false positive owing to this `xlen` mistake?

```
NCList.c: At top level:
NCList.c:1303:13: warning: ‘NCList_get_y_overlaps_rec’ defined but not used [-Wunused-function]
 1303 | static void NCList_get_y_overlaps_rec(const NCList *x_nclist,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
NCList.c:203:22: warning: ‘next_top_down’ defined but not used [-Wunused-function]
  203 | static const NCList *next_top_down(NCListWalkingStack *stack,
      |                      ^~~~~~~~~~~~~
```